### PR TITLE
Fix nodes in replicaset unable to talk to each other

### DIFF
--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -48,6 +48,7 @@ spec:
             - rs0
             - "--smallfiles"
             - "--noprealloc"
+            - "--bind_ip_all"
           ports:
             - containerPort: 27017
           volumeMounts:


### PR DESCRIPTION
By default mongod command starts the daemon and binds to `127.0.0.1:27017`. This is a problem because, port 27017 on every node is unreachable from every other node. This can be tested by creating the stateful cluster on kubernetes and trying to run db queries by logging into one of the nodes, for example `kubectl exec -it mongo-0 -- mongo --host mongo-0.mongo,mongo-1.mongo,mongo-2.mongo`. By passing the flag `--bind_ip_all`, the nodes are able to talk to each other.