### PR TITLE
Update StatefulSet definition with mongodb 4.2

### DIFF
--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -25,13 +25,16 @@ spec:
   selector:
     role: mongo
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mongo
 spec:
   serviceName: "mongo"
   replicas: 3
+  selector:
+    matchLabels:
+      role: mongo
   template:
     metadata:
       labels:
@@ -46,8 +49,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
-            - "--smallfiles"
-            - "--noprealloc"
+            - "--bind_ip"
+            - 0.0.0.0
           ports:
             - containerPort: 27017
           volumeMounts:


### PR DESCRIPTION
Mongodb 4.2 deprecated some flags, refs: https://docs.mongodb.com/manual/reference/configuration-options/#removed-mmapv1-options